### PR TITLE
Make URLs absolute only in #getAbsoluteUrls

### DIFF
--- a/src/UrlExtractor.php
+++ b/src/UrlExtractor.php
@@ -282,7 +282,7 @@ class UrlExtractor
      */
     private static function isAbsoluteUrl($url)
     {
-        return filter_var($url, FILTER_VALIDATE_URL);
+        return (bool) filter_var($url, FILTER_VALIDATE_URL);
     }
 
     /**

--- a/tests/UrlExtractorTest.php
+++ b/tests/UrlExtractorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+require_once '../src/UrlExtractor.php';
+
+use PHPUnit\Framework\TestCase;
+
+class UrlExtractorTest extends TestCase
+{
+    /**
+     * @var UrlExtractor
+     */
+    private $urlExtractor;
+
+    /**
+     * @var string
+     */
+    private $file = 'page.html';
+
+    /**
+     * @return string
+     */
+    private function getHtml()
+    {
+        return file_get_contents($this->file);
+    }
+
+    /**
+     * @return UrlExtractor
+     */
+    private function getUrlExtractor()
+    {
+        if (!$this->urlExtractor) {
+            $this->urlExtractor = new UrlExtractor($this->getHtml());
+            $this->urlExtractor->setHomeUrl('https://en.wikipedia.org');
+            $this->urlExtractor->setFilesOnly(true);
+        }
+
+        return $this->urlExtractor;
+    }
+
+    /**
+     * The home URL should only include links with the scheme defined.
+     */
+    public function testSetHomeUrlException()
+    {
+        $this->expectException(Exception::class);
+
+        $this->getUrlExtractor()->setHomeUrl('www.bad-url.com');
+    }
+
+    /**
+     * We should get multiple URLs from the content.
+     */
+    public function testGetUrls()
+    {
+        $urls = $this->getUrlExtractor()->getUrls();
+
+        $this->assertTrue(count($urls) > 3);
+    }
+
+    /**
+     * @depends testGetUrls
+     */
+    public function testGetAbsoluteUrls()
+    {
+        $urls = $this->getUrlExtractor()->getAbsoluteUrls();
+
+        $this->assertTrue(count($urls) > 3);
+    }
+
+    /**
+     * The absolute URLs returned should all be valid.
+     */
+    public function testAbsoluteUrlsAreValid()
+    {
+        $urls = $this->getUrlExtractor()->getAbsoluteUrls();
+
+        foreach ($urls as $url) {
+            $isValid = (bool) filter_var($url, FILTER_VALIDATE_URL);
+            $this->assertTrue($isValid);
+        }
+    }
+}

--- a/tests/page.html
+++ b/tests/page.html
@@ -1,0 +1,302 @@
+<div id="content" class="mw-body __web-inspector-hide-shortcut__" role="main">
+    <a id="top"></a>
+    <div id="siteNotice" class="mw-body-content">
+        <div id="centralNotice"></div>
+        <!-- CentralNotice -->
+    </div>
+    <div class="mw-indicators mw-body-content">
+        <div id="mw-indicator-pp-autoreview" class="mw-indicator">
+            <a href="/wiki/Wikipedia:Protection_policy#pc1" title="All edits by unregistered and new users are subject to review prior to becoming visible to unregistered users"><img alt="Page protected with pending changes level 1" src="//upload.wikimedia.org/wikipedia/en/thumb/2/28/Padlock-silver-light.svg/20px-Padlock-silver-light.svg.png" width="20" height="20" srcset="//upload.wikimedia.org/wikipedia/en/thumb/2/28/Padlock-silver-light.svg/30px-Padlock-silver-light.svg.png 1.5x, //upload.wikimedia.org/wikipedia/en/thumb/2/28/Padlock-silver-light.svg/40px-Padlock-silver-light.svg.png 2x" data-file-width="128" data-file-height="128"></a>
+        </div>
+    </div>
+    <h1 id="firstHeading" class="firstHeading" lang="en">William Riker</h1>
+    <div id="bodyContent" class="mw-body-content">
+        <div id="siteSub" class="noprint">From Wikipedia, the free encyclopedia</div>
+        <div id="contentSub">
+            <div id="mw-fr-revisiontag" class="flaggedrevs_short flaggedrevs_stable_synced plainlinks noprint nomobile">
+                <div class="flaggedrevs_short_basic"><img class="flaggedrevs-icon" src="/w/extensions/FlaggedRevs/frontend/modules/img/doc-magnify.png" alt="Changes must be reviewed before being displayed on this page." title="Changes must be reviewed before being displayed on this page."><img id="mw-fr-revisiontoggle" class="fr-toggle-arrow" src="/w/extensions/FlaggedRevs/frontend/modules/img/arrow-down.png" style="display: inline;" alt="show/hide details"></div>
+                <div id="mw-fr-revisiondetails-wrapper" style="position:relative;">
+                    <div id="mw-fr-revisiondetails" class="flaggedrevs_short_details" style="display:none">This is the <a href="/wiki/Wikipedia:Pending_changes" title="Wikipedia:Pending changes">latest accepted revision</a>, <a class="external text" href="//en.wikipedia.org/w/index.php?title=Special:Log&amp;type=review&amp;page=William_Riker">reviewed</a> on <i>8 January 2018</i>.</div>
+                </div>
+            </div>
+        </div>
+        <div id="jump-to-nav" class="mw-jump">
+            Jump to: <a href="#mw-head">navigation</a>, <a href="#p-search">search</a>
+        </div>
+        <div id="mw-content-text" lang="en" dir="ltr" class="mw-content-ltr">
+            <div class="mw-parser-output">
+                <div role="note" class="hatnote navigation-not-searchable">For other uses, see <a href="/wiki/William_Riker_(disambiguation)" class="mw-disambig" title="William Riker (disambiguation)">William Riker (disambiguation)</a>.</div>
+                <table class="infobox" style="width:22em;border-spacing: 2px 5px;">
+                    <tbody>
+                        <tr>
+                            <th colspan="2" style="text-align:center;font-size:125%;font-weight:bold;background: #DEDEE2;">William Riker</th>
+                        </tr>
+                        <tr>
+                            <td colspan="2" style="text-align:center"><i><a href="/wiki/Star_Trek" title="Star Trek">Star Trek</a></i> character</td>
+                        </tr>
+                        <tr>
+                            <td colspan="2" style="text-align:center">
+                                <a href="/wiki/File:WilRiker.jpg" class="image"><img alt="WilRiker.jpg" src="//upload.wikimedia.org/wikipedia/en/thumb/2/20/WilRiker.jpg/220px-WilRiker.jpg" width="220" height="268" srcset="//upload.wikimedia.org/wikipedia/en/2/20/WilRiker.jpg 1.5x" data-file-width="286" data-file-height="348"></a>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">First appearance</th>
+                            <td>"<a href="/wiki/Encounter_at_Farpoint" title="Encounter at Farpoint">Encounter at Farpoint</a>" (<i><a href="/wiki/Star_Trek:_The_Next_Generation" title="Star Trek: The Next Generation">TNG</a></i>)</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Portrayed by</th>
+                            <td><a href="/wiki/Jonathan_Frakes" title="Jonathan Frakes">Jonathan Frakes</a></td>
+                        </tr>
+                        <tr>
+                            <th colspan="2" style="text-align:center;background: #DEDEE2;">Information</th>
+                        </tr>
+                        <tr>
+                            <th scope="row"><a href="/wiki/List_of_Star_Trek_races" title="List of Star Trek races">Species</a></th>
+                            <td>Human</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Affiliation</th>
+                            <td>
+                                <div class="plainlist">
+                                    <ul>
+                                        <li><a href="/wiki/United_Federation_of_Planets" title="United Federation of Planets">United Federation of Planets</a></li>
+                                        <li><a href="/wiki/Starfleet" title="Starfleet">Starfleet</a></li>
+                                    </ul>
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Posting</th>
+                            <td>
+                                <div class="plainlist">
+                                    <ul>
+                                        <li><a href="/wiki/USS_Titan_(NCC-80102)" class="mw-redirect" title="USS Titan (NCC-80102)">USS Titan</a> (<i><a href="/wiki/Star_Trek_Nemesis" class="mw-redirect" title="Star Trek Nemesis">NEM</a></i>)</li>
+                                        <li><a href="/wiki/USS_Enterprise_(NCC-1701-E)" title="USS Enterprise (NCC-1701-E)">USS Enterprise-E</a></li>
+                                        <li>(<i><a href="/wiki/Star_Trek_First_Contact" class="mw-redirect" title="Star Trek First Contact">FCT</a></i>, <i><a href="/wiki/Star_Trek_Insurrection" class="mw-redirect" title="Star Trek Insurrection">INS</a></i>, <i><a href="/wiki/Star_Trek_Nemesis" class="mw-redirect" title="Star Trek Nemesis">NEM</a></i>)</li>
+                                        <li><a href="/wiki/USS_Enterprise_(NCC-1701-D)" title="USS Enterprise (NCC-1701-D)">USS Enterprise-D</a></li>
+                                        <li>(Seasons 1-7, <i><a href="/wiki/Star_Trek_Generations" title="Star Trek Generations">GEN</a></i>)</li>
+                                    </ul>
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Position</th>
+                            <td>
+                                <div class="plainlist">
+                                    <ul>
+                                        <li>Commanding Officer</li>
+                                        <li>(USS Enterprise-D,</li>
+                                        <li>USS Titan)</li>
+                                        <li>First Officer</li>
+                                        <li>(USS Enterprise-E,</li>
+                                        <li>USS Enterprise-D)</li>
+                                    </ul>
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><a href="/wiki/Star_Trek_uniforms" title="Star Trek uniforms">Rank</a></th>
+                            <td>
+                                <div class="plainlist">
+                                    <ul>
+                                        <li><a href="/wiki/Starfleet_ranks_and_insignia" class="mw-redirect" title="Starfleet ranks and insignia">Captain</a> (temporarily Season 4, <i><a href="/wiki/Star_Trek_Nemesis" class="mw-redirect" title="Star Trek Nemesis">NEM</a></i>)</li>
+                                        <li><a href="/wiki/Starfleet_ranks_and_insignia" class="mw-redirect" title="Starfleet ranks and insignia">Commander</a> (Seasons 1-7, Movies)</li>
+                                    </ul>
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Partner</th>
+                            <td><a href="/wiki/Deanna_Troi" title="Deanna Troi">Deanna Troi</a></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p><b>William Thomas</b> "<b>Will</b>" <b>Riker</b>,<sup id="cite_ref-1" class="reference"><a href="#cite_note-1">[1]</a></sup> played by <a href="/wiki/Jonathan_Frakes" title="Jonathan Frakes">Jonathan Frakes</a>, is a fictional character in the <i><a href="/wiki/Star_Trek" title="Star Trek">Star Trek</a></i> <a href="/wiki/Fictional_universe" title="Fictional universe">universe</a> appearing primarily as a main character in <i><a href="/wiki/Star_Trek:_The_Next_Generation" title="Star Trek: The Next Generation">Star Trek: The Next Generation</a></i>. Throughout the series and its accompanying <a href="/wiki/Star_Trek_(film_series)#The_Next_Generation_films" title="Star Trek (film series)">films</a>, he is the <i><a href="/wiki/USS_Enterprise_(NCC-1701-D)" title="USS Enterprise (NCC-1701-D)">Enterprise</a>'s</i> first officer, and briefly captain, until he accepts command of the USS <i>Titan</i> at the end of <i><a href="/wiki/Star_Trek:_Nemesis" title="Star Trek: Nemesis">Star Trek: Nemesis</a></i>.</p>
+                <p></p>
+                <div id="toc" class="toc">
+                    <div class="toctitle" lang="en" dir="ltr" xml:lang="en">
+                        <h2>Contents</h2>
+                        <span class="toctoggle">&nbsp;[<a role="button" tabindex="0" class="togglelink">hide</a>]&nbsp;</span></div>
+                    <ul>
+                        <li class="toclevel-1 tocsection-1"><a href="#Casting"><span class="tocnumber">1</span> <span class="toctext">Casting</span></a></li>
+                        <li class="toclevel-1 tocsection-2"><a href="#Depiction"><span class="tocnumber">2</span> <span class="toctext">Depiction</span></a></li>
+                        <li class="toclevel-1 tocsection-3"><a href="#Guest_appearances"><span class="tocnumber">3</span> <span class="toctext">Guest appearances</span></a></li>
+                        <li class="toclevel-1 tocsection-4"><a href="#Notes"><span class="tocnumber">4</span> <span class="toctext">Notes</span></a></li>
+                        <li class="toclevel-1 tocsection-5"><a href="#References"><span class="tocnumber">5</span> <span class="toctext">References</span></a></li>
+                        <li class="toclevel-1 tocsection-6"><a href="#External_links"><span class="tocnumber">6</span> <span class="toctext">External links</span></a></li>
+                    </ul>
+                </div>
+                <p></p>
+                <h2><span class="mw-headline" id="Casting">Casting</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=William_Riker&amp;action=edit&amp;section=1" title="Edit section: Casting">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+                <p>Frakes went to seven auditions over six weeks before being cast as Riker. Frakes stated: "I started with the cattle call, then the casting director, the producer, then other directors, to <a href="/wiki/Gene_Roddenberry" title="Gene Roddenberry">Gene Roddenberry</a>, and then through the Paramount execs, including the vice-president himself and the heads of television."<sup id="cite_ref-2" class="reference"><a href="#cite_note-2">[2]</a></sup></p>
+                <h2><span class="mw-headline" id="Depiction">Depiction</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=William_Riker&amp;action=edit&amp;section=2" title="Edit section: Depiction">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+                <p>For the first two seasons, Riker is portrayed as a bold, confident and sometimes arrogant, ambitious young officer; however, over time Riker's character becomes more reserved, as experience teaches him the wisdom of a patient, careful approach. He becomes comfortable on the <i>Enterprise</i>, repeatedly turning down offers of his own command, and he learns to cherish the company of his fellow officers. Nonetheless, Riker retains a willingness to occasionally disregard the chain of command. Riker is usually referred to as "Will", although in early first-season episodes of <i>TNG</i> he is sometimes called "Bill" by <a href="/wiki/Deanna_Troi" title="Deanna Troi">Deanna Troi</a>. He is also usually (and informally) called "Number One" by <a href="/wiki/Jean-Luc_Picard" title="Jean-Luc Picard">Captain Picard</a>, because of his position as first officer on the <i>Enterprise</i>.</p>
+                <p>Riker's background is first explored in the second-season episode "<a href="/wiki/The_Icarus_Factor" title="The Icarus Factor">The Icarus Factor</a>". In the episode, Riker's estranged father, Kyle, visits the <i>Enterprise</i> to offer his son the command of the USS <i>Aries</i>, which Riker refuses. We learn that: Riker grew up in <a href="/wiki/Alaska" title="Alaska">Alaska</a>;<sup id="cite_ref-3" class="reference"><a href="#cite_note-3">[3]</a></sup> that his mother, Elizabeth (Betty), died when he was two years old; and that he was raised by his father until the age of 15, when he left home. In the episode, Riker had not spoken with his father for 15 years, but they manage to partially mend their relationship over a game of martial-arts <a href="/wiki/Sparring" title="Sparring">sparring</a> called Anbo-jitsu. In the episode "<a href="/wiki/Lower_Decks" title="Lower Decks">Lower Decks</a>" a waiter at Ten Forward mistakenly states that Riker is <a href="/wiki/Canadian" class="mw-redirect" title="Canadian">Canadian</a>, but in the same episode Riker clarifies that he grew up in Alaska. According to the <i>Voyager</i> episode "Death Wish" (in which Riker made a guest appearance), Riker's distant ancestors also lived in the United States: during the <a href="/wiki/American_Civil_War" title="American Civil War">American Civil War</a>, his ancestor Colonel Thaddeus Riker fought on the Union side, as an officer in the <a href="/wiki/102nd_New_York_Volunteer_Infantry" title="102nd New York Volunteer Infantry">102nd New York Infantry Regiment</a> during the <a href="/wiki/Atlanta_Campaign" title="Atlanta Campaign">Atlanta Campaign</a>.</p>
+                <p>In the two-part episode "<a href="/wiki/The_Best_of_Both_Worlds_(Star_Trek:_The_Next_Generation)" title="The Best of Both Worlds (Star Trek: The Next Generation)">The Best of Both Worlds</a>" Riker takes command of the <i>Enterprise</i>, assuming the rank of captain through a <a href="/wiki/Field_promotion" class="mw-redirect" title="Field promotion">field promotion</a> and orchestrates Picard's rescue. This episode also explores the idea of Riker being unwilling to take chances since he had grown comfortable in his role as First Officer aboard the <i>Enterprise</i>. By the end of the episode, when he orders the <i>Enterprise</i> to fire on former Captain Picard, now Locutus of Borg, Riker has grown into a more confident leader. The sixth-season episode "<a href="/wiki/Second_Chances_(Star_Trek:_The_Next_Generation)" title="Second Chances (Star Trek: The Next Generation)">Second Chances</a>" reveals that Will Riker was duplicated long ago by a <a href="/wiki/Transporter_(Star_Trek)" title="Transporter (Star Trek)">transporter</a> malfunction. The "second" Riker takes the name "<a href="/wiki/Thomas_Riker" class="mw-redirect" title="Thomas Riker">Thomas</a>", which is revealed to be William Riker's middle name. In the seventh-season episode "<a href="/wiki/The_Pegasus_(Star_Trek:_The_Next_Generation)" title="The Pegasus (Star Trek: The Next Generation)">The <i>Pegasus</i></a>", Riker must confront his former commanding officer, Admiral Erik Pressman, over a cover-up related to the destruction of the USS <i>Pegasus</i>. The <i>Pegasus</i> had illegally developed a radically different type of cloaking device that also allowed it to phase through matter, resulting in it becoming fused within an asteroid when unstable power consumption forced the cloaking device offline. In the <i>Enterprise</i> series finale, Riker appears as a never before seen cook discussing matters of life, duty, and sacrifice with the crew. It is revealed that his presence is part of a holodeck simulation of historic events that Riker initiated in order to help himself make the decision to inform Captain Picard of the illegal research once conducted by Admiral Pressman aboard the Pegasus.</p>
+                <p>Before the beginning of the series, Riker was involved in a romantic relationship with <a href="/wiki/Deanna_Troi" title="Deanna Troi">Counselor Troi</a> on her home planet <a href="/wiki/Betazoid" class="mw-redirect" title="Betazoid">Betazed</a>. They often refer to each other as <i>imzadi</i>, a Betazoid term of endearment meaning "beloved". The novel <i><a href="/wiki/Imzadi" title="Imzadi">Imzadi</a></i> takes place before the beginning of the series and explores the history of the relationship between the two characters. The two characters are close friends throughout the series, but their relationship does not resume until <i><a href="/wiki/Star_Trek:_Insurrection" title="Star Trek: Insurrection">Star Trek: Insurrection</a></i>, the third <i>Star Trek</i> film set in the <i>Next Generation</i> era, although Thomas Riker, the duplicate created by a transporter malfunction, attempts to respark their relationship in "Second Chances". The following movie, <i><a href="/wiki/Star_Trek_Nemesis" class="mw-redirect" title="Star Trek Nemesis">Star Trek Nemesis</a></i>, begins with their wedding on board the <i>Enterprise</i>-E. At the start of the film, Riker finally accepts a promotion to <a href="/wiki/Starfleet_ranks_and_insignia" class="mw-redirect" title="Starfleet ranks and insignia">Captain</a> and an offer to command the USS <i>Titan</i>; during the movie's final scenes he bids Picard, and the <i>Enterprise</i>, farewell.</p>
+                <p>Riker was originally scripted as a much more serious, by-the-book officer—by the middle episodes of the first season, however, it was felt that he was too "official", and his character was toned down and became more of a ladies' man.<sup class="noprint Inline-Template Template-Fact" style="white-space:nowrap;">[<i><a href="/wiki/Wikipedia:Citation_needed" title="Wikipedia:Citation needed"><span title="This claim needs references to reliable sources. (April 2013)">citation needed</span></a></i>]</sup> Although Riker was clean-shaven for the first season, he grew a beard at the start of the second season that later would become something of a trademark. Frakes had grown a beard between seasons, for his role in the <a href="/wiki/American_Civil_War" title="American Civil War">Civil War</a> miniseries "<a href="/wiki/North_and_South_(miniseries)" title="North and South (miniseries)">North and South</a>", and Gene Roddenberry asked him to keep it, because he thought it made Riker look more nautical.<sup id="cite_ref-4" class="reference"><a href="#cite_note-4">[4]</a></sup></p>
+                <h2><span class="mw-headline" id="Guest_appearances">Guest appearances</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=William_Riker&amp;action=edit&amp;section=3" title="Edit section: Guest appearances">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+                <p>Frakes appeared in dual roles in "<a href="/wiki/Second_Chances_(TNG_episode)" class="mw-redirect" title="Second Chances (TNG episode)">Second Chances</a>", a <i>TNG</i> episode in which it was established that Riker had a "twin" created years earlier by a transporter malfunction. Frakes appeared as the twin, <a href="/wiki/Thomas_Riker" class="mw-redirect" title="Thomas Riker">Thomas Riker</a>, in the <i><a href="/wiki/Star_Trek:_Deep_Space_Nine" title="Star Trek: Deep Space Nine">Star Trek: Deep Space Nine</a></i> episode "<a href="/wiki/Defiant_(DS9_episode)" class="mw-redirect" title="Defiant (DS9 episode)">Defiant</a>", in which he impersonates the other Riker to commandeer the starship <i>Defiant</i> as a member of the Maquis. The following year he guest-starred as Commander Riker along with Q in the <i><a href="/wiki/Star_Trek:_Voyager" title="Star Trek: Voyager">Star Trek: Voyager</a></i> episode "<a href="/wiki/Death_Wish_(Star_Trek:_Voyager)" title="Death Wish (Star Trek: Voyager)">Death Wish</a>". Frakes reprised his role of Commander Riker in the 2005 <i><a href="/wiki/Star_Trek:_Enterprise" title="Star Trek: Enterprise">Enterprise</a></i> series finale, "<a href="/wiki/These_Are_the_Voyages..." title="These Are the Voyages...">These Are the Voyages...</a>". Frakes also played Riker in an advert for <a href="/wiki/Boole_%26_Babbage" title="Boole &amp; Babbage">Boole &amp; Babbage</a>.</p>
+                <h2><span class="mw-headline" id="Notes">Notes</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=William_Riker&amp;action=edit&amp;section=4" title="Edit section: Notes">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+                <div class="reflist" style="list-style-type: decimal;">
+                    <div class="mw-references-wrap">
+                        <ol class="references">
+                            <li id="cite_note-1"><span class="mw-cite-backlink"><b><a href="#cite_ref-1"><span class="cite-accessibility-label">Jump up </span>^</a>
+                                </b>
+                                </span> <span class="reference-text">David, Peter. <i>Q-Squared</i>. Pocket Books, 1994</span></li>
+                            <li id="cite_note-2"><span class="mw-cite-backlink"><b><a href="#cite_ref-2"><span class="cite-accessibility-label">Jump up </span>^</a>
+                                </b>
+                                </span> <span class="reference-text">Schrager, pp. 48–49.</span></li>
+                            <li id="cite_note-3"><span class="mw-cite-backlink"><b><a href="#cite_ref-3"><span class="cite-accessibility-label">Jump up </span>^</a>
+                                </b>
+                                </span> <span class="reference-text"><cite class="citation web"><a rel="nofollow" class="external text" href="http://www.startrek.com/database_article/riker-william">"Riker, William"</a>. <i>StarTrek.com</i>.</cite><span title="ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&amp;rft.genre=unknown&amp;rft.jtitle=StarTrek.com&amp;rft.atitle=Riker%2C+William&amp;rft_id=http%3A%2F%2Fwww.startrek.com%2Fdatabase_article%2Friker-william&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AWilliam+Riker" class="Z3988"><span style="display:none;">&nbsp;</span></span>
+                                </span>
+                            </li>
+                            <li id="cite_note-4"><span class="mw-cite-backlink"><b><a href="#cite_ref-4"><span class="cite-accessibility-label">Jump up </span>^</a>
+                                </b>
+                                </span> <span class="reference-text"><cite class="citation web">Harris, Will. <a rel="nofollow" class="external text" href="http://www.avclub.com/article/jonathan-frakes-talks-william-riker-playing-trombo-100891">"Jonathan Frakes talks William Riker, playing trombone with Phish, and more"</a>.</cite><span title="ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook&amp;rft.genre=unknown&amp;rft.btitle=Jonathan+Frakes+talks+William+Riker%2C+playing+trombone+with+Phish%2C+and+more&amp;rft.aulast=Harris&amp;rft.aufirst=Will&amp;rft_id=http%3A%2F%2Fwww.avclub.com%2Farticle%2Fjonathan-frakes-talks-william-riker-playing-trombo-100891&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AWilliam+Riker" class="Z3988"><span style="display:none;">&nbsp;</span></span>
+                                </span>
+                            </li>
+                        </ol>
+                    </div>
+                </div>
+                <h2><span class="mw-headline" id="References">References</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=William_Riker&amp;action=edit&amp;section=5" title="Edit section: References">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+                <ul>
+                    <li><cite class="citation book">Schrager, Adam (1997). <i>The Finest Crew in the Fleet: The Next Generation Cast On Screen and Off</i>. New York: Wolf Valley Books. <a href="/wiki/International_Standard_Book_Number" title="International Standard Book Number">ISBN</a>&nbsp;<a href="/wiki/Special:BookSources/1-888149-03-5" title="Special:BookSources/1-888149-03-5">1-888149-03-5</a>.</cite><span title="ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook&amp;rft.genre=book&amp;rft.btitle=The+Finest+Crew+in+the+Fleet%3A+The+Next+Generation+Cast+On+Screen+and+Off&amp;rft.place=New+York&amp;rft.pub=Wolf+Valley+Books&amp;rft.date=1997&amp;rft.isbn=1-888149-03-5&amp;rft.aulast=Schrager&amp;rft.aufirst=Adam&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AWilliam+Riker" class="Z3988"><span style="display:none;">&nbsp;</span></span>
+                    </li>
+                </ul>
+                <h2><span class="mw-headline" id="External_links">External links</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=William_Riker&amp;action=edit&amp;section=6" title="Edit section: External links">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+                <table role="presentation" class="mbox-small plainlinks sistersitebox" style="background-color:#f9f9f9;border:1px solid #aaa;color:#000">
+                    <tbody>
+                        <tr>
+                            <td class="mbox-image"><img alt="" src="//upload.wikimedia.org/wikipedia/commons/thumb/f/fa/Wikiquote-logo.svg/34px-Wikiquote-logo.svg.png" width="34" height="40" class="noviewer" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/f/fa/Wikiquote-logo.svg/51px-Wikiquote-logo.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/f/fa/Wikiquote-logo.svg/68px-Wikiquote-logo.svg.png 2x" data-file-width="300" data-file-height="355"></td>
+                            <td class="mbox-text plainlist">Wikiquote has quotations related to: <i><b><a href="https://en.wikiquote.org/wiki/Star_Trek" class="extiw" title="q:Star Trek">Star Trek</a></b></i></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <ul>
+                    <li><a rel="nofollow" class="external text" href="http://www.startrek.com/database_article/riker-william">Character biography at official <i>Star Trek</i> website</a></li>
+                    <li><a rel="nofollow" class="external text" href="http://memory-alpha.org/wiki/William_Riker">William Riker</a> at <a href="/wiki/Memory_Alpha" title="Memory Alpha">Memory Alpha</a> (a <i><a href="/wiki/Star_Trek" title="Star Trek">Star Trek</a></i> <a href="/wiki/Wiki" title="Wiki">wiki</a>)</li>
+                </ul>
+                <div role="navigation" class="navbox" aria-labelledby="Star_Trek:_The_Next_Generation" style="padding:3px">
+                    <table class="nowraplinks collapsible autocollapse navbox-inner" style="border-spacing:0;background:transparent;color:inherit" id="collapsibleTable0">
+                        <tbody>
+                            <tr>
+                                <th scope="col" class="navbox-title" colspan="2"><span class="collapseButton">[<a id="collapseButton0" href="#">hide</a>]</span>
+                                    <div class="plainlinks hlist navbar mini">
+                                        <ul>
+                                            <li class="nv-view"><a href="/wiki/Template:Star_Trek:_The_Next_Generation" title="Template:Star Trek: The Next Generation"><abbr title="View this template" style=";;background:none transparent;border:none;-moz-box-shadow:none;-webkit-box-shadow:none;box-shadow:none;">v</abbr></a></li>
+                                            <li class="nv-talk"><a href="/wiki/Template_talk:Star_Trek:_The_Next_Generation" title="Template talk:Star Trek: The Next Generation"><abbr title="Discuss this template" style=";;background:none transparent;border:none;-moz-box-shadow:none;-webkit-box-shadow:none;box-shadow:none;">t</abbr></a></li>
+                                            <li class="nv-edit"><a class="external text" href="//en.wikipedia.org/w/index.php?title=Template:Star_Trek:_The_Next_Generation&amp;action=edit"><abbr title="Edit this template" style=";;background:none transparent;border:none;-moz-box-shadow:none;-webkit-box-shadow:none;box-shadow:none;">e</abbr></a></li>
+                                        </ul>
+                                    </div>
+                                    <div id="Star_Trek:_The_Next_Generation" style="font-size:114%;margin:0 4em"><i><a href="/wiki/Star_Trek:_The_Next_Generation" title="Star Trek: The Next Generation">Star Trek: The Next Generation</a></i></div>
+                                </th>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="navbox-group" style="width:1%"><a href="/wiki/List_of_Star_Trek:_The_Next_Generation_characters" title="List of Star Trek: The Next Generation characters">Characters</a></th>
+                                <td class="navbox-list navbox-odd hlist" style="text-align:left;border-left-width:2px;border-left-style:solid;width:100%;padding:0px">
+                                    <div style="padding:0em 0.25em">
+                                        <ul>
+                                            <li><a href="/wiki/Beverly_Crusher" title="Beverly Crusher">Beverly Crusher</a></li>
+                                            <li><a href="/wiki/Wesley_Crusher" title="Wesley Crusher">Wesley Crusher</a></li>
+                                            <li><a href="/wiki/Data_(Star_Trek)" title="Data (Star Trek)">Data</a></li>
+                                            <li><a href="/wiki/Geordi_La_Forge" title="Geordi La Forge">Geordi La Forge</a></li>
+                                            <li><a href="/wiki/Jean-Luc_Picard" title="Jean-Luc Picard">Jean-Luc Picard</a></li>
+                                            <li><a href="/wiki/Katherine_Pulaski" title="Katherine Pulaski">Katherine Pulaski</a></li>
+                                            <li><a class="mw-selflink selflink">William Riker</a></li>
+                                            <li><a href="/wiki/Deanna_Troi" title="Deanna Troi">Deanna Troi</a></li>
+                                            <li><a href="/wiki/Worf" title="Worf">Worf</a></li>
+                                            <li><a href="/wiki/Tasha_Yar" title="Tasha Yar">Tasha Yar</a></li>
+                                        </ul>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="navbox-group" style="width:1%"><a href="/wiki/List_of_Star_Trek:_The_Next_Generation_episodes" title="List of Star Trek: The Next Generation episodes">Episodes</a></th>
+                                <td class="navbox-list navbox-even hlist" style="text-align:left;border-left-width:2px;border-left-style:solid;width:100%;padding:0px">
+                                    <div style="padding:0em 0.25em">
+                                        <ul>
+                                            <li><a href="/wiki/Star_Trek:_The_Next_Generation_(season_1)" title="Star Trek: The Next Generation (season 1)">Season 1</a></li>
+                                            <li><a href="/wiki/Star_Trek:_The_Next_Generation_(season_2)" title="Star Trek: The Next Generation (season 2)">2</a></li>
+                                            <li><a href="/wiki/Star_Trek:_The_Next_Generation_(season_3)" title="Star Trek: The Next Generation (season 3)">3</a></li>
+                                            <li><a href="/wiki/Star_Trek:_The_Next_Generation_(season_4)" title="Star Trek: The Next Generation (season 4)">4</a></li>
+                                            <li><a href="/wiki/Star_Trek:_The_Next_Generation_(season_5)" title="Star Trek: The Next Generation (season 5)">5</a></li>
+                                            <li><a href="/wiki/Star_Trek:_The_Next_Generation_(season_6)" title="Star Trek: The Next Generation (season 6)">6</a></li>
+                                            <li><a href="/wiki/Star_Trek:_The_Next_Generation_(season_7)" title="Star Trek: The Next Generation (season 7)">7</a></li>
+                                        </ul>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="navbox-group" style="width:1%"><a href="/wiki/Star_Trek_(film_series)" title="Star Trek (film series)">Films</a></th>
+                                <td class="navbox-list navbox-odd hlist" style="text-align:left;border-left-width:2px;border-left-style:solid;width:100%;padding:0px">
+                                    <div style="padding:0em 0.25em">
+                                        <ul>
+                                            <li><i><a href="/wiki/Star_Trek_Generations" title="Star Trek Generations">Generations</a></i></li>
+                                            <li><i><a href="/wiki/Star_Trek:_First_Contact" title="Star Trek: First Contact">First Contact</a></i></li>
+                                            <li><i><a href="/wiki/Star_Trek:_Insurrection" title="Star Trek: Insurrection">Insurrection</a></i></li>
+                                            <li><i><a href="/wiki/Star_Trek:_Nemesis" title="Star Trek: Nemesis">Nemesis</a></i></li>
+                                        </ul>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row" class="navbox-group" style="width:1%">Other topics</th>
+                                <td class="navbox-list navbox-even hlist" style="text-align:left;border-left-width:2px;border-left-style:solid;width:100%;padding:0px">
+                                    <div style="padding:0em 0.25em">
+                                        <ul>
+                                            <li><a href="/wiki/List_of_awards_and_nominations_received_by_Star_Trek:_The_Next_Generation" title="List of awards and nominations received by Star Trek: The Next Generation">Awards</a></li>
+                                            <li><a href="/wiki/List_of_Star_Trek:_The_Next_Generation_cast_members" title="List of Star Trek: The Next Generation cast members">Cast</a></li>
+                                            <li><a href="/wiki/USS_Enterprise_(NCC-1701-D)" title="USS Enterprise (NCC-1701-D)">USS <i>Enterprise</i> (NCC-1701-D)</a></li>
+                                            <li><a href="/wiki/USS_Enterprise_(NCC-1701-E)" title="USS Enterprise (NCC-1701-E)">USS <i>Enterprise</i> (NCC-1701-E)</a></li>
+                                            <li>"<a href="/wiki/These_Are_the_Voyages..." title="These Are the Voyages...">These Are the Voyages...</a>"</li>
+                                            <li><i><a href="/wiki/Star_Trek:_Countdown" title="Star Trek: Countdown">Star Trek: Countdown</a></i></li>
+                                            <li><i><a href="/wiki/Star_Trek:_The_Next_Generation_Technical_Manual" title="Star Trek: The Next Generation Technical Manual">Star Trek: The Next Generation Technical Manual</a></i></li>
+                                            <li><i><a href="/wiki/Star_Trek:_The_Next_Generation:_Klingon_Honor_Guard" title="Star Trek: The Next Generation: Klingon Honor Guard">Star Trek: The Next Generation: Klingon Honor Guard</a></i></li>
+                                        </ul>
+                                    </div>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <noscript>&lt;img src="//en.wikipedia.org/wiki/Special:CentralAutoLogin/start?type=1x1" alt="" title="" width="1" height="1" style="border: none; position: absolute;" /&gt;</noscript>
+        </div>
+        <div class="printfooter">
+            Retrieved from "<a dir="ltr" href=" https://en.wikipedia.org/w/index.php?title=William_Riker&amp;oldid=819264156">https://en.wikipedia.org/w/index.php?title=William_Riker&amp;oldid=819264156</a>" </div>
+        <div id="catlinks" class="catlinks" data-mw="interface">
+            <div id="mw-normal-catlinks" class="mw-normal-catlinks"><a href="/wiki/Help:Category" title="Help:Category">Categories</a>:
+                <ul>
+                    <li><a href="/wiki/Category:Star_Trek:_The_Next_Generation_characters" title="Category:Star Trek: The Next Generation characters">Star Trek: The Next Generation characters</a></li>
+                    <li><a href="/wiki/Category:Star_Trek:_Voyager_characters" title="Category:Star Trek: Voyager characters">Star Trek: Voyager characters</a></li>
+                    <li><a href="/wiki/Category:Star_Trek:_Enterprise_characters" title="Category:Star Trek: Enterprise characters">Star Trek: Enterprise characters</a></li>
+                    <li><a href="/wiki/Category:Star_Trek_(film_franchise)_characters" title="Category:Star Trek (film franchise) characters">Star Trek (film franchise) characters</a></li>
+                    <li><a href="/wiki/Category:Starfleet_officers" title="Category:Starfleet officers">Starfleet officers</a></li>
+                    <li><a href="/wiki/Category:Fictional_military_captains" title="Category:Fictional military captains">Fictional military captains</a></li>
+                    <li><a href="/wiki/Category:Fictional_chefs" title="Category:Fictional chefs">Fictional chefs</a></li>
+                    <li><a href="/wiki/Category:Fictional_commanders" title="Category:Fictional commanders">Fictional commanders</a></li>
+                    <li><a href="/wiki/Category:Fictional_first_officers" title="Category:Fictional first officers">Fictional first officers</a></li>
+                    <li><a href="/wiki/Category:Starfleet_admirals" title="Category:Starfleet admirals">Starfleet admirals</a></li>
+                    <li><a href="/wiki/Category:Fictional_jazz_musicians" title="Category:Fictional jazz musicians">Fictional jazz musicians</a></li>
+                    <li><a href="/wiki/Category:Fictional_actors" title="Category:Fictional actors">Fictional actors</a></li>
+                    <li><a href="/wiki/Category:Fictional_characters_from_Alaska" title="Category:Fictional characters from Alaska">Fictional characters from Alaska</a></li>
+                    <li><a href="/wiki/Category:Starfleet_captains" title="Category:Starfleet captains">Starfleet captains</a></li>
+                    <li><a href="/wiki/Category:Starfleet_commanders" title="Category:Starfleet commanders">Starfleet commanders</a></li>
+                    <li><a href="/wiki/Category:Fictional_characters_introduced_in_1987" title="Category:Fictional characters introduced in 1987">Fictional characters introduced in 1987</a></li>
+                </ul>
+            </div>
+            <div id="mw-hidden-catlinks" class="mw-hidden-catlinks mw-hidden-cats-hidden">Hidden categories:
+                <ul>
+                    <li><a href="/wiki/Category:Wikipedia_pending_changes_protected_pages" title="Category:Wikipedia pending changes protected pages">Wikipedia pending changes protected pages</a></li>
+                    <li><a href="/wiki/Category:Pages_using_deprecated_image_syntax" title="Category:Pages using deprecated image syntax">Pages using deprecated image syntax</a></li>
+                    <li><a href="/wiki/Category:Articles_using_Infobox_character_with_multiple_unlabeled_fields" title="Category:Articles using Infobox character with multiple unlabeled fields">Articles using Infobox character with multiple unlabeled fields</a></li>
+                    <li><a href="/wiki/Category:All_articles_with_unsourced_statements" title="Category:All articles with unsourced statements">All articles with unsourced statements</a></li>
+                    <li><a href="/wiki/Category:Articles_with_unsourced_statements_from_April_2013" title="Category:Articles with unsourced statements from April 2013">Articles with unsourced statements from April 2013</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="visualClear"></div>
+    </div>
+</div>


### PR DESCRIPTION
This allows the original URL strings to be returned with #getUrls and provides a different method, #getAbsoluteUrls, to return them as absolute URLs.